### PR TITLE
getDeviceLocalIPAsString: keep error context

### DIFF
--- a/src/js/common/browserInfoHelper.js
+++ b/src/js/common/browserInfoHelper.js
@@ -17,7 +17,7 @@ export const getDeviceLocalIPAsString = () => {
     }
     const WebRTCConnection = globalsUtil.getWebRTCConnection();
     if (!WebRTCConnection) {
-      reject("WEBRTC_UNSUPPORTED_BROWSER");
+      reject({message: "WEBRTC_UNSUPPORTED_BROWSER", error: undefined});
     }
     //RTCPeerConection is supported, so will try to find the IP
     const ip = [];
@@ -25,14 +25,14 @@ export const getDeviceLocalIPAsString = () => {
     try {
       pc = new WebRTCConnection();
     } catch (err) {
-      reject("WEBRTC_CONSTRUCTION_FAILED");
+      reject({message: "WEBRTC_CONSTRUCTION_FAILED", error: err});
     }
 
     pc.onicecandidate = (event) => {
       if (!event || !event.candidate) {
         pc.close();
         if (ip.length < 1) {
-          reject("NO_IP_FOUND");
+          reject({message: "NO_IP_FOUND", error: undefined});
         }
         deviceIpString = ip.join(",");
         resolve(deviceIpString);
@@ -48,7 +48,7 @@ export const getDeviceLocalIPAsString = () => {
     pc.createOffer()
         .then(pc.setLocalDescription.bind(pc))
         .catch((e) => {
-            reject("CREATE_CONNECTION_ERROR");
+            reject({message: "CREATE_CONNECTION_ERROR", error: e});
       });
   });
 };


### PR DESCRIPTION
## Description of what's changing

Change `reject("string")` calls to `reject({message: "string", error: error|undefined})` calls.

## What else might be impacted?

This is a breaking change—it changes the error type of the resulting Promise object.

Any consumers of this function will need to change their error handling logic.

## Which issue does this PR relate to?

Here's one take on why this is important: https://www.yegor256.com/2015/12/01/rethrow-exceptions.html

The basic idea is to help whoever has to deal with these errors by giving them more useful information. In this case, we capture the errors (when available) and keep the original messages.

For example, this means we get to keep the stack-trace in the error, a useful debugging aid (where did this error come from?).

For more, see the discussion at https://github.com/intuit/user-data-for-fraud-prevention/issues/31

## Checklist

[ ] Tests are written and maintain or improve code coverage
[ ] I've tested this in my application using `yarn link` (if applicable)
[ ] You consent to and are confident this change can be released with no regression