### PR TITLE
chore: moved usage instructions to another file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,30 +16,7 @@ Eg: Tax Authority in UK (HMRC) requires software providers using some of their A
 Each top level folder in `src/js` has its own README with more specific information around the use case. E.g. [HMRC README](src/js/hmrc/README.md)
 
 ## How to use
-
-In your project root run:
-
-```sh
-yarn add user-data-for-fraud-prevention
-```
-
-Then to use in code:
-
-```js
-import getFraudPreventionHeaders from 'user-data-for-fraud-prevention';
-// or
-import {getFraudPreventionHeaders, fraudPreventionHeadersEnum} from 'user-data-for-fraud-prevention';
-```
-
-To use
-
-```js
-const fraudHeaders = await getFraudPreventionHeaders();
-// If you need individual headers
-const timezoneHeader = fraudHeaders.get('Gov-Client-Timezone');
-// Or
-const timezoneHeader = fraudHeaders.get(fraudPreventionHeadersEnum.TIMEZONE);
-```
+Usage instructions can be found [here](./USAGE.md)
 
 ## Demo
 You can find a demo of the project [here](https://github.com/reubenae/user-data-demo)

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,25 @@
+## Usage 
+
+In your project root run:
+
+```sh
+yarn add user-data-for-fraud-prevention
+```
+
+Then to use in code:
+
+```js
+import getFraudPreventionHeaders from 'user-data-for-fraud-prevention';
+// or
+import {getFraudPreventionHeaders, fraudPreventionHeadersEnum} from 'user-data-for-fraud-prevention';
+```
+
+To use
+
+```js
+const fraudHeaders = await getFraudPreventionHeaders();
+// If you need individual headers
+const timezoneHeader = fraudHeaders.get('Gov-Client-Timezone');
+// Or
+const timezoneHeader = fraudHeaders.get(fraudPreventionHeadersEnum.TIMEZONE);
+```


### PR DESCRIPTION
# Title
Moved HMRC fraud header usage to USAGE.md

## Description of what's changing
Created a new file USAGE.md and moved the usage examples to it

## What else might be impacted?
None

## Which issue does this PR relate to?
#8 

## Checklist

[x] Tests are written and maintain or improve code coverage
[x] I've tested this in my application using `yarn link` (if applicable)
[x] You consent to and are confident this change can be released with no regression
