### PR TITLE
Add and configured all-contributions bot

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,24 @@
+{
+  "projectName": "user-data-for-fraud-prevention",
+  "projectOwner": "skodamarthi",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "rachelquan",
+      "name": "Rachel Quan",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/39972689?v=4",
+      "profile": "http://rachelquan.xyz/",
+      "contributions": [
+        "tool"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # user-data-for-fraud-prevention
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![user-data-for-fraud-prevention logo](./user-data-for-fraud-prevention-logo.png)
 
 [![CircleCI](https://circleci.com/gh/intuit/user-data-for-fraud-prevention/tree/master.svg?style=shield)](https://circleci.com/gh/intuit/user-data-for-fraud-prevention/tree/master)
 ![Contributions welcome](https://img.shields.io/badge/contributions-welcome-orange)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # user-data-for-fraud-prevention
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![user-data-for-fraud-prevention logo](./user-data-for-fraud-prevention-logo.png)
 
@@ -64,3 +67,17 @@ You can find a demo of the project [here](https://github.com/reubenae/user-data-
 Please see our [CHANGELOG](CHANGELOG.md)
 
 ## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="http://rachelquan.xyz/"><img src="https://avatars1.githubusercontent.com/u/39972689?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Rachel Quan</b></sub></a><br /><a href="#tool-rachelquan" title="Tools">🔧</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ You can find a demo of the project [here](https://github.com/reubenae/user-data-
 1. Ensure the code coverage is the same or higher than before your changes.
 1. Create a PR to the `master` branch
 
+## How Contributors can Add Themselves
+
+There are two ways to add yourself as a contributor to this repo:
+
+1. Call @all-contributors bot by adding this following comment in a PR: **@all-contributors please add [username] for [contributions]**. Please refer to the [docs](https://allcontributors.org/docs/en/bot/usage) for more info.
+1. Use the all-contributors-cli by running `npx all-contributors add [username] [contributions]`. Please refer to the [docs](https://allcontributors.org/docs/en/cli/usage) for more info.
+
+All parameters are required.
+See the [Emoji Key (Contribution Types Reference)](https://allcontributors.org/docs/en/emoji-key) for a list of valid contribution types.
+
 ## License
 
 [License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ You can find a demo of the project [here](https://github.com/reubenae/user-data-
 ## Changelog
 
 Please see our [CHANGELOG](CHANGELOG.md)
+
+## Contributors

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 [![CircleCI](https://circleci.com/gh/intuit/user-data-for-fraud-prevention/tree/master.svg?style=shield)](https://circleci.com/gh/intuit/user-data-for-fraud-prevention/tree/master)
 ![Contributions welcome](https://img.shields.io/badge/contributions-welcome-orange)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
+    "all-contributors-cli": "^6.17.4",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.1.0",
     "eslint": "^7.4.0",


### PR DESCRIPTION
# Title

## Description of what's changing
I added the `all-contributors-cli`, so if a developer does `npx all-contributors add [username] doc`, it will automatically add the contributor and the emoji on what they have done to the contributors table in the README.md. 

I also added the `@all-contributors` bot too via GitHub app, so if a developer comments `@all-contributors please add [username] for [contributions]`, it will do the same. 

Here is more info regarding the contribution types (this is mandatory to add): https://allcontributors.org/docs/en/emoji-key

I still need to test the second one, but the first one works. Not sure if we need the first one though, and if not, I can just remove it from the `package.json'.

All configurations of this feature is in the ` .all-contributorsrc` file.

## What else might be impacted?

...

## Which issue does this PR relate to?

#13 

## Checklist

[x] Tests are written and maintain or improve code coverage - My first thought is that I don't have to write tests since I am just adding a bot, and I believe this is only affecting the README.md. Lemme know if I'm wrong though.
[x] I've tested this in my application using `yarn link` (if applicable)
[x] You consent to and are confident this change can be released with no regression
