### PR TITLE
fix: changed to ES6 format

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,7 +1,4 @@
-import {
+export {
   fraudPreventionHeadersEnum,
   getFraudPreventionHeaders,
 } from "./hmrc/mtdFraudPrevention";
-
-exports.fraudPreventionHeadersEnum = fraudPreventionHeadersEnum;
-exports.getFraudPreventionHeaders = getFraudPreventionHeaders;


### PR DESCRIPTION
# Title
Fixing src/js/index.js to be in ES6 format

## Description of what's changing
The syntax of exporting and importing fraudPreventionHeadersEnum and getFraudPreventionHeaders

## What else might be impacted?
Nothing should be impacted by this if all other files are in ES6 format too

## Which issue does this PR relate to?
Add ES6 support (migrate from module.exports to export const) #9

## Checklist

[yes ] Tests are written and maintain or improve code coverage
[ yes] I've tested this in my application using `yarn link` (if applicable)
[ yes] You consent to and are confident this change can be released with no regression
