### PR TITLE
Generate UUID to return as a HMRC header.

### DIFF
--- a/src/js/common/browserInfoHelper.js
+++ b/src/js/common/browserInfoHelper.js
@@ -1,4 +1,5 @@
 import globalsUtil from "./globalsUtil";
+import { v4 as uuidv4 } from 'uuid';
 
 const ICE_CANDIDATE_IP_INDEX = 4;
 
@@ -53,6 +54,9 @@ export const getDeviceLocalIPAsString = () => {
   });
 };
 
+// Get a UUID as the device ID.
+export const getDeviceId = () => uuidv4();
+
 export const getBrowserPluginsAsString = () => {
   return Array.from(globalsUtil.getNavigator().plugins, plugin => plugin && plugin.name)
     .filter((name) => name)
@@ -76,7 +80,7 @@ const getFormattedOffset = () => {
     const minuteOffset = `${offset[3]}${offset[4]}`;
     const formattedUTC = `${hourOffset}:${minuteOffset}`;
     return formattedUTC;
-}
+};
 
 export const getTimezone = () => `UTC${getFormattedOffset()}`;
 export const getScreenWidth = () =>

--- a/src/js/hmrc/mtdFraudPrevention.js
+++ b/src/js/hmrc/mtdFraudPrevention.js
@@ -9,6 +9,7 @@ import {
   getWindowHeight,
   getWindowWidth,
   getTimezone,
+  getDeviceId,
 } from "../common/browserInfoHelper";
 
 /**
@@ -21,6 +22,7 @@ export const fraudPreventionHeadersEnum = {
   BROWSER_PLUGINS: "Gov-Client-Browser-Plugins",
   BROWSER_DONOTTRACK: "Gov-Client-Browser-Do-Not-Track",
   DEVICE_LOCAL_IPS: "Gov-Client-Local-IPs",
+  DEVICE_ID: "Gov-Client-Device-ID",
 };
 
 const getScreenDetails = () => {
@@ -58,6 +60,10 @@ export const getFraudPreventionHeaders = async () => {
     {
       header: fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS,
       callback: async () => encodeURI(await getDeviceLocalIPAsString()),
+    },
+    {
+      header: fraudPreventionHeadersEnum.DEVICE_ID,
+      callback: getDeviceId,
     },
   ];
   for (let i = 0; i < headerFunctions.length; i++) {

--- a/tests/unit/common/browserInfoHelper.test.js
+++ b/tests/unit/common/browserInfoHelper.test.js
@@ -19,6 +19,7 @@ import {
   getWindowWidth,
   getTimezone,
   resetDeviceIpString,
+  getDeviceId,
 } from "../../../src/js/common/browserInfoHelper";
 
 describe("BrowserInfoHelper", () => {
@@ -247,6 +248,10 @@ describe("BrowserInfoHelper", () => {
     expect(getBrowserPluginsAsString()).toEqual("ABC Plugin,XYZ Plugin");
     expect(getBrowserDoNotTrackStatus()).toEqual("true");
     expect(await getDeviceLocalIPAsString()).toEqual("127.0.0.1");
+  });
+
+  it("getDeviceId", async () => {
+    expect(getDeviceId()).toBeTruthy();
   });
 
   it("getScreen", async () => {

--- a/tests/unit/hmrc/mtdFraudPrevention.test.js
+++ b/tests/unit/hmrc/mtdFraudPrevention.test.js
@@ -44,7 +44,7 @@ describe("FraudPreventionHeaders", () => {
     };
 
     const {headers, errors} = await getFraudPreventionHeaders();
-    expect(headers.size).toBe(6);
+    expect(headers.size).toBe(7);
     expect(errors.length).toBe(0);
     expect(headers.get("Gov-Client-Timezone")).toBe(`UTC+01:00`);
     expect(headers.get("Gov-Client-Screens")).toBe(
@@ -58,6 +58,7 @@ describe("FraudPreventionHeaders", () => {
     );
     expect(headers.get("Gov-Client-Browser-Do-Not-Track")).toBe("true");
     expect(headers.get("Gov-Client-Local-IPs")).toBe("127.0.0.1,127.0.0.2");
+    expect(headers.get("Gov-Client-Device-ID")).toBeTruthy();
   });
   it("getFraudPreventionHeaders with one error", async () => {
     jest.spyOn(globalsUtil, "getNavigator").mockReturnValue({
@@ -79,7 +80,7 @@ describe("FraudPreventionHeaders", () => {
     jest.spyOn(browserInfoHelper, "getDeviceLocalIPAsString").mockReturnValue(Promise.reject("Something went wrong."));
 
     const {headers, errors} = await getFraudPreventionHeaders();
-    expect(headers.size).toBe(5);
+    expect(headers.size).toBe(6);
     expect(errors.length).toBe(1);
     expect(headers.get("Gov-Client-Timezone")).toBe(`UTC+01:00`);
     expect(headers.get("Gov-Client-Screens")).toBe(
@@ -93,6 +94,7 @@ describe("FraudPreventionHeaders", () => {
     );
     expect(headers.get("Gov-Client-Browser-Do-Not-Track")).toBe("true");
     expect(headers.get("Gov-Client-Local-IPs")).toBe(undefined);
+    expect(headers.get("Gov-Client-Device-ID")).toBeTruthy();
     expect(errors[0]).toEqual("Something went wrong.");
   });
 });


### PR DESCRIPTION
Generate UUID to return as a HMRC header.

I'm a vGHC 2020 OSD participant and this is my first open source contribution.

## Description of what's changing

Add code to resolve https://github.com/intuit/user-data-for-fraud-prevention/issues/41.

## What else might be impacted?

Minor change to add a missing semicolon in one of the changed files.

## Which issue does this PR relate to?
https://github.com/intuit/user-data-for-fraud-prevention/issues/41

## Checklist

[x] Tests are written and maintain or improve code coverage
[x] I've tested this in my application using `yarn link` (if applicable)
[x] You consent to and are confident this change can be released with no regression
