### PR TITLE
Changing the config to run coverage only for master builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ workflows:
   build:
     jobs:
       - build
-      - coverage
+      - coverage:
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
       - build
       - coverage
         requires:
-          - build
+            - build
         filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ workflows:
     jobs:
       - build
       - coverage
-        requires:
+          requires:
             - build
-        filters:
+          filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,19 @@ jobs:
       # run build
       - run: npm run build
 
-      # run tests and generate coverage
+      # run tests
       - run:
-          name: "Run tests and generate coverage report"
-          command: npm run test:coverage
+          name: "Run tests"
+          command: npm run test
 
       - store_artifacts:
           path: coverage
+  coverage:
+    docker:
+      - image: circleci/node:10.15.3-browsers
+    steps:
+      - checkout
+      - run: npm run test:coverage
 
 notify:
   webhooks:
@@ -39,3 +45,9 @@ workflows:
   build:
     jobs:
       - build
+      - coverage
+        requires:
+          - build
+        filters:
+            branches:
+              only: master


### PR DESCRIPTION
# Title
This is to fix issue with PR build failures related to Coveralls.

## Description of what's changing

...

## What else might be impacted?

...

## Which issue does this PR relate to?

...

## Checklist

[ ] Tests are written and maintain or improve code coverage
[ ] I've tested this in my application using `yarn link` (if applicable)
[ ] You consent to and are confident this change can be released with no regression
