### PR TITLE
QBO-230357 Add Gov-Client-Local-IPs-Timestamp header in HMRC FPH

### DIFF
--- a/src/js/common/browserInfoHelper.js
+++ b/src/js/common/browserInfoHelper.js
@@ -2,12 +2,17 @@ const ICE_CANDIDATE_IP_INDEX = 4;
 
 // store this as a global variable as generating it is expensive and often required several times
 let deviceIpString = "";
+let deviceIpTimeStamp = "";
 
 /**
  * This reset function is valuable only for unit testing
  */
 export const resetDeviceIpString = () => {
   deviceIpString = "";
+};
+
+export const resetDeviceIpTimeStamp = () => {
+  deviceIpTimeStamp = "";
 };
 
 /**
@@ -41,6 +46,7 @@ export const getDeviceLocalIPAsString = () => {
           reject({message: "NO_IP_FOUND", error: undefined});
         }
         deviceIpString = ip.join(",");
+        deviceIpTimeStamp = new Date().toISOString();
         resolve(deviceIpString);
       }
       else if (event.candidate.candidate) {
@@ -57,6 +63,15 @@ export const getDeviceLocalIPAsString = () => {
             reject({message: "CREATE_CONNECTION_ERROR", error: err});
       });
   });
+};
+
+export const getDeviceLocalIPTimeStamp = () => {
+  return new Promise((resolve, reject) => {
+    if (deviceIpTimeStamp === "") {
+      reject({message: "NO_IP_TIMESTAMP_FOUND", error: undefined})
+    }
+    resolve(deviceIpTimeStamp);
+  })
 };
 
 /**

--- a/src/js/common/browserInfoHelper.js
+++ b/src/js/common/browserInfoHelper.js
@@ -1,6 +1,6 @@
 const ICE_CANDIDATE_IP_INDEX = 4;
 
-// store this as a global variable as generating it is expensive and often required several times
+// store deviceIpString as a global variable as generating it is expensive and often required several times
 const deviceIpData = {
   deviceIpString: "",
   deviceIpTimeStamp: ""
@@ -25,7 +25,7 @@ export const resetDeviceIpTimeStamp = () => {
  */
 export const getDeviceLocalIPAsString = () => {
   return new Promise((resolve, reject) => {
-    if (deviceIpData.deviceIpString != "" && deviceIpData.deviceIpTimeStamp != "") {
+    if (deviceIpData.deviceIpString !== "" && deviceIpData.deviceIpTimeStamp !== "") {
       resolve(deviceIpData);
     }
     const WebRTCConnection = RTCPeerConnection;

--- a/src/js/common/browserInfoHelper.js
+++ b/src/js/common/browserInfoHelper.js
@@ -1,18 +1,20 @@
 const ICE_CANDIDATE_IP_INDEX = 4;
 
 // store this as a global variable as generating it is expensive and often required several times
-let deviceIpString = "";
-let deviceIpTimeStamp = "";
+const deviceIpData = {
+  deviceIpString: "",
+  deviceIpTimeStamp: ""
+}
 
 /**
  * This reset function is valuable only for unit testing
  */
 export const resetDeviceIpString = () => {
-  deviceIpString = "";
+  deviceIpData.deviceIpString = "";
 };
 
 export const resetDeviceIpTimeStamp = () => {
-  deviceIpTimeStamp = "";
+  deviceIpData.deviceIpTimeStamp = "";
 };
 
 /**
@@ -23,8 +25,8 @@ export const resetDeviceIpTimeStamp = () => {
  */
 export const getDeviceLocalIPAsString = () => {
   return new Promise((resolve, reject) => {
-    if (deviceIpString) {
-      resolve(deviceIpString);
+    if (deviceIpData.deviceIpString != "" && deviceIpData.deviceIpTimeStamp != "") {
+      resolve(deviceIpData);
     }
     const WebRTCConnection = RTCPeerConnection;
     if (!WebRTCConnection) {
@@ -45,9 +47,9 @@ export const getDeviceLocalIPAsString = () => {
         if (ip.length < 1) {
           reject({message: "NO_IP_FOUND", error: undefined});
         }
-        deviceIpString = ip.join(",");
-        deviceIpTimeStamp = new Date().toISOString();
-        resolve(deviceIpString);
+        deviceIpData.deviceIpString = ip.join(",");
+        deviceIpData.deviceIpTimeStamp = new Date().toISOString();
+        resolve(deviceIpData);
       }
       else if (event.candidate.candidate) {
         const candidateValues = event.candidate.candidate.split(" ");
@@ -63,15 +65,6 @@ export const getDeviceLocalIPAsString = () => {
             reject({message: "CREATE_CONNECTION_ERROR", error: err});
       });
   });
-};
-
-export const getDeviceLocalIPTimeStamp = () => {
-  return new Promise((resolve, reject) => {
-    if (deviceIpTimeStamp === "") {
-      reject({message: "NO_IP_TIMESTAMP_FOUND", error: undefined})
-    }
-    resolve(deviceIpTimeStamp);
-  })
 };
 
 /**

--- a/src/js/hmrc/mtdFraudPrevention.js
+++ b/src/js/hmrc/mtdFraudPrevention.js
@@ -92,7 +92,7 @@ export const getFraudPreventionHeaders = async () => {
   try {
     const ipAddress = await getDeviceLocalIPAsString();
     headers.set(fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS, encodeURI(ipAddress.deviceIpString));
-    headers.set(fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS_TIMESTAMP, encodeURI(ipAddress.deviceIpTimeStamp));
+    headers.set(fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS_TIMESTAMP, ipAddress.deviceIpTimeStamp);
 
   } catch (error) {
     errors.push(error);

--- a/src/js/hmrc/mtdFraudPrevention.js
+++ b/src/js/hmrc/mtdFraudPrevention.js
@@ -78,14 +78,6 @@ export const getFraudPreventionHeaders = async () => {
       header: fraudPreventionHeadersEnum.BROWSER_DONOTTRACK,
       callback: getBrowserDoNotTrackStatus,
     },
-    {
-      header: fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS,
-      callback: async () => encodeURI(await getDeviceLocalIPAsString()),
-    },
-    { 
-      header: fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS_TIMESTAMP,
-      callback: async () => encodeURI(await getDeviceLocalIPTimeStamp()),
-    },
     { header: fraudPreventionHeadersEnum.DEVICE_ID, callback: generateClientDeviceID},
   ];
   for (let i = 0; i < headerFunctions.length; i++) {
@@ -97,5 +89,16 @@ export const getFraudPreventionHeaders = async () => {
       errors.push(error);
     }
   }
+
+  try {
+    const ipAddress = await getDeviceLocalIPAsString();
+
+    headers.set(fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS, encodeURI(ipAddress.deviceIpString));
+    headers.set(fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS_TIMESTAMP, encodeURI(ipAddress.deviceIpTimeStamp));
+
+  } catch (error) {
+    errors.push(error);
+  }
+
   return { headers, errors };
 };

--- a/src/js/hmrc/mtdFraudPrevention.js
+++ b/src/js/hmrc/mtdFraudPrevention.js
@@ -1,6 +1,5 @@
 import {
   getDeviceLocalIPAsString,
-  getDeviceLocalIPTimeStamp,
   getBrowserDoNotTrackStatus,
   getBrowserPluginsAsString,
   getScreenColourDepth,
@@ -92,7 +91,6 @@ export const getFraudPreventionHeaders = async () => {
 
   try {
     const ipAddress = await getDeviceLocalIPAsString();
-
     headers.set(fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS, encodeURI(ipAddress.deviceIpString));
     headers.set(fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS_TIMESTAMP, encodeURI(ipAddress.deviceIpTimeStamp));
 

--- a/src/js/hmrc/mtdFraudPrevention.js
+++ b/src/js/hmrc/mtdFraudPrevention.js
@@ -1,5 +1,6 @@
 import {
   getDeviceLocalIPAsString,
+  getDeviceLocalIPTimeStamp,
   getBrowserDoNotTrackStatus,
   getBrowserPluginsAsString,
   getScreenColourDepth,
@@ -26,6 +27,7 @@ export const fraudPreventionHeadersEnum = {
   BROWSER_DONOTTRACK: "Gov-Client-Browser-Do-Not-Track",
   DEVICE_LOCAL_IPS: "Gov-Client-Local-IPs",
   DEVICE_ID: "Gov-Client-Device-ID",
+  DEVICE_LOCAL_IPS_TIMESTAMP: "Gov-Client-Local-IPs-Timestamp",
 };
 
 const getScreenData = () => {
@@ -79,6 +81,10 @@ export const getFraudPreventionHeaders = async () => {
     {
       header: fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS,
       callback: async () => encodeURI(await getDeviceLocalIPAsString()),
+    },
+    { 
+      header: fraudPreventionHeadersEnum.DEVICE_LOCAL_IPS_TIMESTAMP,
+      callback: async () => encodeURI(await getDeviceLocalIPTimeStamp()),
     },
     { header: fraudPreventionHeadersEnum.DEVICE_ID, callback: generateClientDeviceID},
   ];

--- a/tests/unit/common/browserInfoHelper.test.js
+++ b/tests/unit/common/browserInfoHelper.test.js
@@ -18,8 +18,6 @@ import {
   getWindowWidth,
   getTimezone,
   resetDeviceIpString,
-  getDeviceLocalIPTimeStamp,
-  resetDeviceIpTimeStamp,
 } from "../../../src/js/common/browserInfoHelper";
 
 expect.extend({

--- a/tests/unit/common/browserInfoHelper.test.js
+++ b/tests/unit/common/browserInfoHelper.test.js
@@ -38,6 +38,18 @@ expect.extend({
 describe("BrowserInfoHelper", () => {
   let screenSpy, navigatorSpy, windowSpy;
 
+  const mockTimeStamp = "2021-06-03T13:02:22.107Z"
+  global.Date = class DateMock {
+    constructor() {
+    }
+    toString() {
+        return "Tue May 14 2019 12:01:58 GMT+0100 (British Summer Time)";
+    }
+    toISOString() {
+        return mockTimeStamp;
+    }
+};
+
   beforeEach(() => {
     screenSpy = jest.spyOn(global, 'screen', 'get');
     navigatorSpy = jest.spyOn(global, 'navigator', 'get');
@@ -209,9 +221,9 @@ describe("BrowserInfoHelper", () => {
 
     it("RTCPeerConnection valid", async () => {
       global.RTCPeerConnection = MockRTCPeerConnection;
-      expect(await getDeviceLocalIPAsString()).toEqual("127.0.0.1");
+      expect(await getDeviceLocalIPAsString()).toEqual({"deviceIpString": "127.0.0.1", "deviceIpTimeStamp": mockTimeStamp});
       // Calling the function to return an already calculated deviceIpString
-      expect(await getDeviceLocalIPAsString()).toEqual("127.0.0.1");
+      expect(await getDeviceLocalIPAsString()).toEqual({"deviceIpString": "127.0.0.1", "deviceIpTimeStamp": mockTimeStamp});
     });
 
     it("RTCPeerConnection returns 5th item in array after splitting", async () => {
@@ -219,40 +231,7 @@ describe("BrowserInfoHelper", () => {
         "abc xyz 123 567 789 777 127.0.0.1 randomstring somestring"
       );
       global.RTCPeerConnection = MockRTCPeerConnection;
-      expect(await getDeviceLocalIPAsString()).toEqual("789");
-    });
-  });
-
-  describe("getDeviceLocalIPTimeStamp", () => {
-    beforeEach(() => {
-      resetDeviceIpTimeStamp();
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-      resetDeviceIpTimeStamp();
-    });
-
-    it("getDeviceLocalIPTimeStamp throws NO_IP_TIMESTAMP_FOUND for empty timestamp string", async () => {
-      await expect(async() => getDeviceLocalIPTimeStamp())
-      .rejects
-      .toBeErrorWithMessage('NO_IP_TIMESTAMP_FOUND');  
-    });
-
-    it("getDeviceLocalIPTimeStamp returns timestamp after IP has been retrieved", async () => {
-      const mockTimeStamp = "2021-06-03T13:02:22.107Z"
-      global.RTCPeerConnection = MockRTCPeerConnection;
-      global.Date = class DateMock {
-        constructor() {
-        }
-        toISOString() {
-            return mockTimeStamp;
-        }
-    };
-      const dateSpy = jest.spyOn(global.Date.prototype, 'toISOString');
-      await getDeviceLocalIPAsString();
-      expect(dateSpy).toHaveBeenCalled();
-      expect(await getDeviceLocalIPTimeStamp()).toEqual(mockTimeStamp);
+      expect(await getDeviceLocalIPAsString()).toEqual({"deviceIpString": "789", "deviceIpTimeStamp": mockTimeStamp});
     });
   });
 
@@ -269,23 +248,12 @@ describe("BrowserInfoHelper", () => {
     }));
 
     global.RTCPeerConnection = MockRTCPeerConnection;
-    const mockTimeStamp = "2021-06-03T13:02:22.107Z"
 
     screenSpy.mockImplementation(() => ({
       width: 1019,
       height: 1021,
       colorDepth: 17,
     }));
-    global.Date = class DateMock {
-        constructor() {
-        }
-        toString() {
-            return "Tue May 14 2019 12:01:58 GMT+0100 (British Summer Time)";
-        }
-        toISOString() {
-            return mockTimeStamp;
-        }
-    };
 
     expect(getTimezone()).toEqual(`UTC+01:00`);
     expect(getScreenWidth()).toEqual(1019);
@@ -296,8 +264,7 @@ describe("BrowserInfoHelper", () => {
     expect(getWindowHeight()).toEqual(1013);
     expect(getBrowserPluginsAsString()).toEqual("ABC Plugin,XYZ Plugin");
     expect(getBrowserDoNotTrackStatus()).toEqual("true");
-    expect(await getDeviceLocalIPAsString()).toEqual("127.0.0.1");
-    expect(await getDeviceLocalIPTimeStamp()).toEqual(mockTimeStamp);
+    expect(await getDeviceLocalIPAsString()).toEqual({"deviceIpString": "127.0.0.1", "deviceIpTimeStamp": mockTimeStamp});
   });
 
   it("getScreen", async () => {

--- a/tests/unit/hmrc/mtdFraudPrevention.test.js
+++ b/tests/unit/hmrc/mtdFraudPrevention.test.js
@@ -158,7 +158,7 @@ describe("FraudPreventionHeaders", () => {
     const {headers, errors} = await getFraudPreventionHeaders();
     expect(headers.size).toBe(6);
     expect(errors.length).toBe(1);
-    expect(headers.get("Gov-Client-Timezone")).toBe("UTC+01:00");
+    expect(headers.get("Gov-Client-Timezone")).toBe(`UTC+01:00`);
     expect(headers.get("Gov-Client-Screens")).toBe(
       "width=1019&height=1021&scaling-factor=2&colour-depth=17"
     );

--- a/tests/unit/hmrc/mtdFraudPrevention.test.js
+++ b/tests/unit/hmrc/mtdFraudPrevention.test.js
@@ -35,6 +35,18 @@ describe("FraudPreventionHeaders", () => {
     resetCandidateString();
   });
 
+  const mockTimeStamp = "2021-06-03T13:02:22.107Z"
+  global.Date = class DateMock {
+      constructor() {
+      }
+      toString() {
+          return "Tue May 14 2019 12:01:58 GMT+0100 (British Summer Time)";
+      }
+      toISOString() {
+        return mockTimeStamp;
+    }
+  };
+
   it("getFraudPreventionHeaders with no errors", async () => {
     navigatorSpy.mockImplementation(() => ({
       plugins: getMockBrowserPluginDetails(),
@@ -55,17 +67,6 @@ describe("FraudPreventionHeaders", () => {
     }));
 
     jest.spyOn(uuid, "v4").mockReturnValue("134b0eb1-4e27-40a3-82b7-ab28f7d5ee79");
-    const mockTimeStamp = "2021-06-03T13:02:22.107Z"
-    global.Date = class DateMock {
-        constructor() {
-        }
-        toString() {
-            return "Tue May 14 2019 12:01:58 GMT+0100 (British Summer Time)";
-        }
-        toISOString() {
-          return mockTimeStamp;
-      }
-    };
 
     const {headers, errors} = await getFraudPreventionHeaders();
     expect(headers.size).toBe(8);
@@ -106,13 +107,58 @@ describe("FraudPreventionHeaders", () => {
       colorDepth: 17,
     }));
 
-    jest.spyOn(browserInfoHelper, "getDeviceLocalIPAsString").mockReturnValue(Promise.reject("Something went wrong."));
+    const timeZoneMock = jest.spyOn(browserInfoHelper, "getTimezone").mockReturnValue(Promise.reject("Something went wrong."));
+    jest.spyOn(uuid, "v4").mockReturnValue("fce4f7ff-d5f1-4e4f-99a1-aa97bef71e99");
+
+    const {headers, errors} = await getFraudPreventionHeaders();
+    expect(headers.size).toBe(7);
+    expect(errors.length).toBe(1);
+    expect(headers.get("Gov-Client-Timezone")).toBe(undefined);
+    expect(headers.get("Gov-Client-Screens")).toBe(
+      "width=1019&height=1021&scaling-factor=2&colour-depth=17"
+    );
+    expect(headers.get("Gov-Client-Window-Size")).toBe(
+      "width=1009&height=1013"
+    );
+    expect(headers.get("Gov-Client-Browser-Plugins")).toBe(
+      "ABC%20Plugin,XYZ%20Plugin"
+    );
+    expect(headers.get("Gov-Client-Browser-Do-Not-Track")).toBe("true");
+    expect(headers.get("Gov-Client-Local-IPs")).toBe("127.0.0.1,127.0.0.2");
+    expect(headers.get("Gov-Client-Local-IPs-Timestamp")).toBe(mockTimeStamp);
+    expect(headers.get("Gov-Client-Device-ID")).toEqual("fce4f7ff-d5f1-4e4f-99a1-aa97bef71e99");
+    expect(errors[0]).toEqual("Something went wrong.");
+    timeZoneMock.mockRestore();
+  });
+
+  it("getFraudPreventionHeaders with one error (getDeviceLocalIPAsString)", async () => {
+
+    navigatorSpy.mockImplementation(() => ({
+      plugins: getMockBrowserPluginDetails(),
+      doNotTrack: "yes",
+    }));
+
+    setAdditionalCandidateString(",127.0.0.2");
+
+    windowSpy.mockImplementation(() => ({
+      devicePixelRatio: 2,
+      innerWidth: 1009,
+      innerHeight: 1013,
+    }));
+
+    screenSpy.mockImplementation(() => ({
+      width: 1019,
+      height: 1021,
+      colorDepth: 17,
+    }));
+
+    const deviceLocalIpMock = jest.spyOn(browserInfoHelper, "getDeviceLocalIPAsString").mockReturnValue(Promise.reject("Something went wrong."));
     jest.spyOn(uuid, "v4").mockReturnValue("fce4f7ff-d5f1-4e4f-99a1-aa97bef71e99");
 
     const {headers, errors} = await getFraudPreventionHeaders();
     expect(headers.size).toBe(6);
     expect(errors.length).toBe(1);
-    expect(headers.get("Gov-Client-Timezone")).toBe(`UTC+01:00`);
+    expect(headers.get("Gov-Client-Timezone")).toBe("UTC+01:00");
     expect(headers.get("Gov-Client-Screens")).toBe(
       "width=1019&height=1021&scaling-factor=2&colour-depth=17"
     );
@@ -124,9 +170,12 @@ describe("FraudPreventionHeaders", () => {
     );
     expect(headers.get("Gov-Client-Browser-Do-Not-Track")).toBe("true");
     expect(headers.get("Gov-Client-Local-IPs")).toBe(undefined);
+    expect(headers.get("Gov-Client-Local-IPs-Timestamp")).toBe(undefined);
     expect(headers.get("Gov-Client-Device-ID")).toEqual("fce4f7ff-d5f1-4e4f-99a1-aa97bef71e99");
     expect(errors[0]).toEqual("Something went wrong.");
+    deviceLocalIpMock.mockRestore();
   });
+
   describe("screen details", () => {
     beforeEach(() => {
       screenSpy.mockImplementation(() => ({

--- a/tests/unit/hmrc/mtdFraudPrevention.test.js
+++ b/tests/unit/hmrc/mtdFraudPrevention.test.js
@@ -110,7 +110,7 @@ describe("FraudPreventionHeaders", () => {
     jest.spyOn(uuid, "v4").mockReturnValue("fce4f7ff-d5f1-4e4f-99a1-aa97bef71e99");
 
     const {headers, errors} = await getFraudPreventionHeaders();
-    expect(headers.size).toBe(7);
+    expect(headers.size).toBe(6);
     expect(errors.length).toBe(1);
     expect(headers.get("Gov-Client-Timezone")).toBe(`UTC+01:00`);
     expect(headers.get("Gov-Client-Screens")).toBe(


### PR DESCRIPTION


# QBO-230357 Add Gov-Client-Local-IPs-Timestamp header in HMRC FPH

## Description of what's changing
Record and store timestamp of when local IP is collected to send as a header (Gov-Client-Local-IPs-Timestamp) in the format yyyy-MM-ddThh:mm:ss.sssZ

...

## What else might be impacted?

...

## Which issue does this PR relate to?

...

## Checklist

[ ] Tests are written and maintain or improve code coverage
[ ] I've tested this in my application using `yarn link` (if applicable)
[ ] You consent to and are confident this change can be released with no regression
