### PR TITLE
feat(hmrc #143): adding getGovClientDeviceIDHeader function

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -32,8 +32,8 @@ import getGovClientBrowserPluginsHeader from 'user-data-for-fraud-prevention';
 const {headerValue, error} = getGovClientBrowserPluginsHeader();
 ```
 
-* To get Gov-Client-Browser-Do-Not-Track HMRC Fraud prevention header:
+* To get Gov-Client-Device-ID HMRC Fraud prevention header:
 ```
-import getGovClientBrowserDoNotTrackHeader from 'user-data-for-fraud-prevention';
-const {headerValue, error} = getGovClientBrowserDoNotTrackHeader();
+import getGovClientDeviceIDHeader from 'user-data-for-fraud-prevention';
+const {headerValue, error} = getGovClientDeviceIDHeader();
 ```

--- a/src/js/hmrc/mtdFraudPrevention.js
+++ b/src/js/hmrc/mtdFraudPrevention.js
@@ -115,11 +115,11 @@ export const getGovClientBrowserPluginsHeader = () => {
 }
 
 /**
- * Returns the value for Gov-Client-Browser-Do-Not-Track HMRC Fraud prevention header.
+ * Returns the value for Gov-Client-Device-ID HMRC Fraud prevention header.
  */
-export const getGovClientBrowserDoNotTrackHeader = () => {
+export const getGovClientDeviceIDHeader = () => {
   try {
-    return {headerValue: getBrowserDoNotTrackStatus()};
+    return {headerValue: generateClientDeviceID()};
   } catch (error) {
     return {error}; 
   }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,14 +3,14 @@ import {
   getFraudPreventionHeaders,
   getScreenDetails,
   windowDetails,
+  getGovClientDeviceIDHeader,
   getGovClientBrowserPluginsHeader,
-  getGovClientBrowserDoNotTrackHeader,
 } from "./hmrc/mtdFraudPrevention";
 
 exports.fraudPreventionHeadersEnum = fraudPreventionHeadersEnum;
 exports.getFraudPreventionHeaders = getFraudPreventionHeaders;
+exports.getGovClientDeviceIDHeader = getGovClientDeviceIDHeader;
 exports.getGovClientBrowserPluginsHeader = getGovClientBrowserPluginsHeader;
-exports.getGovClientBrowserDoNotTrackHeader = getGovClientBrowserDoNotTrackHeader;
 
 exports.getScreenDetails = getScreenDetails;
 exports.windowDetails = windowDetails;

--- a/tests/unit/hmrc/mtdFraudPrevention.test.js
+++ b/tests/unit/hmrc/mtdFraudPrevention.test.js
@@ -12,9 +12,8 @@ import {
 import * as browserInfoHelper from "../../../src/js/common/browserInfoHelper";
 import { resetDeviceIpString, resetDeviceIpTimeStamp } from "../../../src/js/common/browserInfoHelper";
 import uuid from "uuid";
-import {getGovClientBrowserPluginsHeader} from "../../../src/js/hmrc/mtdFraudPrevention";
-import { getGovClientBrowserDoNotTrackHeader } from "../../../src/js/hmrc/mtdFraudPrevention";
-
+import { getGovClientDeviceIDHeader, getGovClientBrowserPluginsHeader } from "../../../src/js/hmrc/mtdFraudPrevention";
+import * as standaloneInfoHelper from "../../../src/js/common/standaloneInfoHelper";
 describe("FraudPreventionHeaders", () => {
   resetDeviceIpString();
   resetDeviceIpTimeStamp();
@@ -235,20 +234,21 @@ describe("getGovClientBrowserPluginsHeader", () => {
 
 });
 
-describe("getGovClientBrowserDoNotTrackHeader", () => {
+describe("getGovClientDeviceIDHeader", () => {
 
-  it("no error", async () => {
-    const {headerValue, error} = await getGovClientBrowserDoNotTrackHeader();
-    expect(headerValue).toBe("true");
+  it("no error", () => {
+    jest.spyOn(uuid, "v4").mockReturnValue("d85e2c1a-3168-11ec-8d3d-0242ac130003");
+    const {headerValue, error} = getGovClientDeviceIDHeader();
+    expect(headerValue).toBe("d85e2c1a-3168-11ec-8d3d-0242ac130003");
     expect(error).toBe(undefined);
   })
 
-  it("getBrowserDoNotTrackStatus throws error", async () => {
-    const browserDoNotTrackStatusMock = jest.spyOn(browserInfoHelper, "getBrowserDoNotTrackStatus").mockImplementation(() => { throw Error("Something went wrong.")});
-    const {headerValue, error} = await getGovClientBrowserDoNotTrackHeader();
+  it("getGovClientDeviceIDHeader throws error", () => {
+    const govClientDeviceIDMock = jest.spyOn(standaloneInfoHelper, "generateClientDeviceID").mockImplementation(() => { throw Error("Something went wrong.")});
+    const {headerValue, error} = getGovClientDeviceIDHeader();
     expect(headerValue).toBe(undefined);
     expect(error).toEqual(Error("Something went wrong."));
-    browserDoNotTrackStatusMock.mockRestore();
+    govClientDeviceIDMock.mockRestore();
   });
 
 });


### PR DESCRIPTION
# Export device ID details header for HMRC (Gov-Client-Device-ID)
PR for feature requested on this issue #143

## Description of what's changing
Added new getGovClientDeviceIDHeader function along with test cases
Updated usage.md for the instructions

## Which issue does this PR relate to?
#143 

## Checklist

[ ] Tests are written and maintain or improve code coverage
[ ] I've tested this in my application using `yarn link` (if applicable)
[ ] You consent to and are confident this change can be released with no regression
