### PR TITLE
Fixes #142 Export local IP address details header for HMRC (Gov-Client-Local-IPs)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -48,9 +48,14 @@ import getGovClientBrowserDoNotTrackHeader from 'user-data-for-fraud-prevention'
 const {headerValue, error} = getGovClientBrowserDoNotTrackHeader();
 ```
 
-
 * To get Gov-Client-Timezone HMRC Fraud prevention header:
-    ```js
-    import getGovClientTimezoneHeader from 'user-data-for-fraud-prevention';
-    const {headerValue, error} = getGovClientTimezoneHeader();
-    ```
+```js
+import getGovClientTimezoneHeader from 'user-data-for-fraud-prevention';
+const {headerValue, error} = getGovClientTimezoneHeader();
+```
+
+* To get Gov-Client-Local-IPs HMRC Fraud prevention header:
+```js
+import getGovClientLocalIPsHeader from 'user-data-for-fraud-prevention';
+const {headerValue, error} = await getGovClientLocalIPsHeader();
+```

--- a/src/js/hmrc/mtdFraudPrevention.js
+++ b/src/js/hmrc/mtdFraudPrevention.js
@@ -157,3 +157,18 @@ export const getGovClientTimezoneHeader = () => {
     return {error};
   }
 }
+
+/**
+ * Returns Gov-Client-Local-IPs header value
+ * @returns {object} which has header key having the value of the header or error key if there is an error
+ */
+export const getGovClientLocalIPsHeader = async () => {
+  try {
+    const ipAddress = await getDeviceLocalIPAsString();
+    return {
+      headerValue: encodeURI(ipAddress.deviceIpString),
+    };
+  } catch (error) {
+    return { error };
+  }
+}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -8,6 +8,7 @@ import {
   getGovClientBrowserDoNotTrackHeader,
   getGovClientDeviceID,
   getGovClientTimezoneHeader,
+  getGovClientLocalIPsHeader,
 } from "./hmrc/mtdFraudPrevention";
 
 exports.fraudPreventionHeadersEnum = fraudPreventionHeadersEnum;
@@ -18,6 +19,7 @@ exports.getGovClientBrowserDoNotTrackHeader = getGovClientBrowserDoNotTrackHeade
 exports.getGovClientDeviceID = getGovClientDeviceID;
 exports.getGovClientTimezoneHeader = getGovClientTimezoneHeader;
 
+exports.getGovClientLocalIPsHeader = getGovClientLocalIPsHeader;
 exports.getScreenDetails = getScreenDetails;
 exports.getGovClientBrowserJSUserAgentHeader = getGovClientBrowserJSUserAgentHeader;
 exports.windowDetails = windowDetails;

--- a/tests/unit/hmrc/mtdFraudPrevention.test.js
+++ b/tests/unit/hmrc/mtdFraudPrevention.test.js
@@ -4,6 +4,7 @@ import {
   getScreenDetails,
   windowDetails,
   getGovClientBrowserJSUserAgentHeader,
+  getGovClientLocalIPsHeader,
 } from "../../../src/js";
 import {
   MockRTCPeerConnection,
@@ -304,5 +305,28 @@ describe("GovClientTimezoneHeader", () => {
     expect(headerValue).toBe(undefined);
     expect(error).toEqual(TypeError("Cannot read property '0' of undefined"));
     dateMock.mockRestore();
+  });
+});
+
+describe("getGovClientLocalIPsHeader", () => {
+  it("returns correct headerValue when there is no error", async () => {
+    setAdditionalCandidateString(",127.0.0.2");
+    const expectedValue = "127.0.0.1,127.0.0.2";
+
+    const header = await getGovClientLocalIPsHeader();
+
+    expect(header.headerValue).toBe(expectedValue);
+    expect(header.error).toBeUndefined();
+  });
+
+  it("returns error when there is an error", async () => {
+    const expectedErrorMessage = "Something went wrong.";
+    const deviceLocalIpMock = jest.spyOn(browserInfoHelper, "getDeviceLocalIPAsString").mockReturnValue(Promise.reject(expectedErrorMessage));
+
+    const header = await getGovClientLocalIPsHeader();
+
+    expect(header.error).toBe(expectedErrorMessage);
+    expect(header.headerValue).toBeUndefined();
+    deviceLocalIpMock.mockRestore();
   });
 });


### PR DESCRIPTION
# Title

## Description of what's changing
Added an utility getGovClientLocalIPsHeader for Gov-Client-Local-IPs header's value

## What else might be impacted?
No impact As this is a new utility

## Which issue does this PR relate to?
#142

## Testing code

```
getGovClientLocalIPsHeader()
  .then((response) => console.log(response))
  .catch((error) => console.log(error))
```

## Checklist

- [x] Tests are written and maintain or improve code coverage
- [x] I've tested this in my application using `yarn link` (if applicable)
- [x] You consent to and are confident this change can be released with no regression