### PR TITLE
chore(npm): replace npm references with yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,18 +16,18 @@ jobs:
     steps:
       - checkout
 
-      - run: npm install
+      - run: yarn
 
       # run lint
-      - run: npm run lint
+      - run: yarn lint
 
       # run build
-      - run: npm run build
+      - run: yarn build
 
       # run tests
       - run:
           name: "Run tests"
-          command: npm run test
+          command: yarn test
 
       - persist_to_workspace:
           root: .
@@ -48,7 +48,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: npm run test:coverage
+      - run: yarn test:coverage
       - store_artifacts:
           path: coverage
 notify:

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Instructions for testing the changes can be found [here](./DEMO.md)
 We do not allow contributors to claim issues. If you find something interesting you can contribute to the repo, feel free to raise a PR. We do not require you to let us know in advance.
 
 1. Fork the repo
-1. Install dependencies locally by running `yarn` or `npm install`
+1. Install dependencies locally by running `yarn`
 1. Make your changes
-1. Make sure it builds using `yarn build` or `npm run build`
-1. Run the tests (you added tests, right?) with `npm test` or `yarn test`
-1. Test your changes in your consuming code or using our demo project: Run [`yarn link`](https://classic.yarnpkg.com/en/docs/cli/link) or [`npm link`](https://docs.npmjs.com/cli/link)
+1. Make sure it builds using `yarn build`
+1. Run the tests (you added tests, right?) with `yarn test`
+1. Test your changes in your consuming code or using our demo project: Run [`yarn link`](https://classic.yarnpkg.com/en/docs/cli/link)
 1. Ensure the code coverage is the same or higher than before your changes
 1. Ensure commit message is properly formatted: `type(subject): input`. Eg: `chore(prettier): update prettier to 2.x`
 1. Create a PR to the `master` branch

--- a/package.json
+++ b/package.json
@@ -5,19 +5,19 @@
   "scripts": {
     "test": "jest",
     "build": "webpack",
-    "test:coverage": "npm test -- --coverage && cat ./coverage/lcov.info | coveralls",
+    "test:coverage": "yarn test -- --coverage && cat ./coverage/lcov.info | coveralls",
     "lint:fix": "eslint '{src,tests}/**/*.{js,ts} --fix",
     "lint": "eslint '{src,tests}/**/*.{js,ts}'",
     "format": "lint-staged",
     "prettier": "prettier '{src,tests}/**/*.{js,ts}' --config .prettierrc --write",
     "prettier:fix": "prettier '{src,tests}/**/*.{js,ts}' --config .prettierrc",
     "clean": "rm -rf node_modules",
-    "rebuild": "npm run clean && npm install && npm run build",
+    "rebuild": "yarn clean && yarn && yarn build",
     "prepublishOnly": "webpack"
   },
   "husky": {
     "hooks": {
-      "pre-push": "npm test",
+      "pre-push": "yarn test",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },


### PR DESCRIPTION
# Remove usages of npm

## Description of what's changing

Replacing all instances of where we are using `npm` with `yarn` in order to address #171 .

One problem with this PR is that I am unable to update the READMEs that are not in English since I only speak English and French. We will need to have the developers who contributed them, or someone else who can speak those languages update the documentation for those languages.

## What else might be impacted?

As long as the build passes, there should be no change for users.

## Which issue does this PR relate to?

This PR fixes #171 .

## Checklist

[ ] Tests are written and maintain or improve code coverage
[ ] I've tested this in my application using `yarn link` (if applicable)
[ ] You consent to and are confident this change can be released with no regression
