### PR TITLE
chore(husky): add lint to husky command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "yarn test",
+      "pre-push": "yarn lint && yarn test",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },


### PR DESCRIPTION
# Add Linting to PrePush Hooks

## Description of what's changing

Husky will now lint before testing as a prepush hook.

## What else might be impacted?

This will impact anyone who tries to push to a remote.

## Which issue does this PR relate to?

#177 

## Checklist

[ ] Tests are written and maintain or improve code coverage
[ ] I've tested this in my application using `yarn link` (if applicable)
[ ] You consent to and are confident this change can be released with no regression
